### PR TITLE
Fix artifact name

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-rootProject.name = "spine-base-types"
+rootProject.name = "base-types"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,4 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// Do not use `spine-` prefix for this single-module project.
+// It would be added automatically when publishing.
 rootProject.name = "base-types"


### PR DESCRIPTION
This PR fixes duplicated `spine-` prefix in the Maven artefact. The version isn't bumped since the previous PR used wrong name.