### PR TITLE
Get rid of a circular dependency on `publish` task

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/Publish.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/Publish.kt
@@ -28,7 +28,7 @@ package io.spine.internal.gradle.dart.task
 
 import io.spine.internal.gradle.TaskName
 import io.spine.internal.gradle.base.assemble
-import io.spine.internal.gradle.java.publish.publish
+import io.spine.internal.gradle.publish.publish
 import io.spine.internal.gradle.named
 import io.spine.internal.gradle.register
 import org.gradle.api.tasks.Copy

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javascript/task/Publish.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javascript/task/Publish.kt
@@ -26,7 +26,7 @@
 
 package io.spine.internal.gradle.javascript.task
 
-import io.spine.internal.gradle.java.publish.publish
+import io.spine.internal.gradle.publish.publish
 import io.spine.internal.gradle.named
 import io.spine.internal.gradle.register
 import io.spine.internal.gradle.TaskName

--- a/license-report.md
+++ b/license-report.md
@@ -525,4 +525,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Apr 04 17:38:32 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 05 13:54:33 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).


### PR DESCRIPTION
This PR pulls [the changes](https://github.com/SpineEventEngine/config/pull/351) from `config` repository that fix a circularity of `publish` task.

The library itself has remained unchanged and its version is preserved intentionally `2.0.0-SNAPSHOT.88`. The previous PR has **not** been published when was merged.