### PR TITLE
Use the latest `modelCompiler` and migrate to Validation runtime library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -208,6 +208,15 @@ tasks {
     }
 }
 
+project.afterEvaluate {
+    val sourcesJar: Task by tasks.getting
+    val dokkaHtml: Task by tasks.getting
+    val launchProtoDataMain: Task by tasks.getting
+
+    sourcesJar.dependsOn(launchProtoDataMain)
+    dokkaHtml.dependsOn(launchProtoDataMain)
+}
+
 CheckStyleConfig.applyTo(project)
 JavadocConfig.applyTo(project)
 PomGenerator.applyTo(project)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,6 @@ buildscript {
 
     val mcJavaVersion: String by extra
     val baseVersion: String by extra
-    val timeVersion: String by extra
     dependencies {
         classpath("io.spine.tools:spine-mc-java-plugins:${mcJavaVersion}:all")
     }
@@ -73,7 +72,6 @@ buildscript {
                 force(
                     "org.jetbrains.dokka:dokka-base:${dokka.version}",
                     "io.spine:spine-base:$baseVersion",
-                    "io.spine:spine-time:$timeVersion",
                 )
             }
         }
@@ -96,7 +94,6 @@ plugins {
 
 apply(from = "$projectDir/version.gradle.kts")
 val baseVersion: String by extra
-val timeVersion: String by extra
 val versionToPublish: String by extra
 
 group = "io.spine"
@@ -115,7 +112,6 @@ configurations {
             force(
                 "org.jetbrains.dokka:dokka-base:${Dokka.version}",
                 "io.spine:spine-base:$baseVersion",
-                "io.spine:spine-time:$timeVersion",
             )
         }
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
     private const val group = "com.google.protobuf"
-    const val version       = "3.21.6"
+    const val version       = "3.21.7"
     val libs = listOf(
         "${group}:protobuf-java:${version}",
         "${group}:protobuf-java-util:${version}",

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -145,8 +145,7 @@ fun doApplyStandard(repositories: RepositoryHandler) = repositories.applyStandar
  * @param shortRepositoryName
  *          the short name of the GitHub repository (e.g. "core-java")
  * @param project
- *          the project which is going to consume or publish artifacts from
- *          the registered repository
+ *          the project which is going to consume artifacts from the repository
  * @see applyGitHubPackages
  */
 @Suppress("unused")
@@ -155,6 +154,27 @@ fun doApplyGitHubPackages(
     shortRepositoryName: String,
     project: Project
 ) = repositories.applyGitHubPackages(shortRepositoryName, project)
+
+/**
+ * Applies the repository hosted at GitHub Packages, to which Spine artifacts were published.
+ *
+ * This method should be used by those wishing to have Spine artifacts published
+ * to GitHub Packages as dependencies.
+ *
+ * @param shortRepositoryName
+ *          short names of the GitHub repository (e.g. "base", "core-java", "model-tools")
+ * @param project
+ *          the project which is going to consume artifacts from repositories
+ */
+fun RepositoryHandler.applyGitHubPackages(shortRepositoryName: String, project: Project) {
+    val repository = gitHub(shortRepositoryName)
+    val credentials = repository.credentials(project)
+
+    credentials?.let {
+        spineMavenRepo(it, repository.releases)
+        spineMavenRepo(it, repository.snapshots)
+    }
+}
 
 /**
  * Applies the repositories hosted at GitHub Packages, to which Spine artifacts were published.
@@ -168,13 +188,9 @@ fun doApplyGitHubPackages(
  *          the project which is going to consume or publish artifacts from
  *          the registered repository
  */
-fun RepositoryHandler.applyGitHubPackages(shortRepositoryName: String, project: Project) {
-    val repository = gitHub(shortRepositoryName)
-    val credentials = repository.credentials(project)
-
-    credentials?.let {
-        spineMavenRepo(it, repository.releases)
-        spineMavenRepo(it, repository.snapshots)
+fun RepositoryHandler.applyGitHubPackages(project: Project, vararg shortRepositoryName: String) {
+    for (name in shortRepositoryName) {
+        applyGitHubPackages(name, project)
     }
 }
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javascript/plugin/Idea.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javascript/plugin/Idea.kt
@@ -49,7 +49,7 @@ fun JsPlugins.idea() {
 
         module {
             sourceDirs.add(srcDir)
-            testSourceDirs.add(testSrcDir)
+            testSources.from(testSrcDir)
 
             excludeDirs.addAll(
                 listOf(

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
@@ -27,7 +27,6 @@
 package io.spine.internal.gradle.kotlin
 
 import org.gradle.jvm.toolchain.JavaLanguageVersion
-import org.gradle.jvm.toolchain.JavaToolchainSpec
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -37,7 +36,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
  */
 fun KotlinJvmProjectExtension.applyJvmToolchain(version: Int) {
     jvmToolchain {
-        (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(version))
+        languageVersion.set(JavaLanguageVersion.of(version))
     }
 }
 

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base-types:2.0.0-SNAPSHOT.97`
+# Dependencies of `io.spine:spine-base-types:2.0.0-SNAPSHOT.108`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -37,17 +37,18 @@
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.21.6.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.21.7.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.21.6.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.21.7.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.6.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.7.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.29.**No license information found**
 1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.5.
      * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
@@ -193,18 +194,18 @@
      * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
      * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.21.6.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.21.7.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.21.6.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.21.7.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.6.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.7.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.20.1.
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.21.7.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -261,9 +262,10 @@
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.spine.protodata. **Name** : protodata-fat-cli. **Version** : 0.2.12.**No license information found**
-1.  **Group** : io.spine.protodata. **Name** : protodata-protoc. **Version** : 0.2.12.**No license information found**
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-extensions. **Version** : 2.0.0-SNAPSHOT.27.**No license information found**
+1.  **Group** : io.spine.protodata. **Name** : protodata-fat-cli. **Version** : 0.2.16.**No license information found**
+1.  **Group** : io.spine.protodata. **Name** : protodata-protoc. **Version** : 0.2.16.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-extensions. **Version** : 2.0.0-SNAPSHOT.29.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.29.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -536,4 +538,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 30 23:39:54 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 06 14:53:14 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base-types</artifactId>
-<version>2.0.0-SNAPSHOT.97</version>
+<version>2.0.0-SNAPSHOT.108</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -26,13 +26,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.107</version>
+    <version>2.0.0-SNAPSHOT.108</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-validate</artifactId>
-    <version>2.0.0-SNAPSHOT.107</version>
+    <version>2.0.0-SNAPSHOT.108</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.validation</groupId>
+    <artifactId>spine-validation-java-runtime</artifactId>
+    <version>2.0.0-SNAPSHOT.29</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -44,7 +50,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.107</version>
+    <version>2.0.0-SNAPSHOT.108</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -61,7 +67,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protoc</artifactId>
-    <version>3.20.1</version>
+    <version>3.21.7</version>
   </dependency>
   <dependency>
     <groupId>com.puppycrawl.tools</groupId>
@@ -76,12 +82,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.2.12</version>
+    <version>0.2.16</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.2.12</version>
+    <version>0.2.16</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -91,18 +97,18 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.99</version>
+    <version>2.0.0-SNAPSHOT.101</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.99</version>
+    <version>2.0.0-SNAPSHOT.101</version>
   </dependency>
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-extensions</artifactId>
-    <version>2.0.0-SNAPSHOT.27</version>
+    <version>2.0.0-SNAPSHOT.29</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,9 +24,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val mcJavaVersion by extra("2.0.0-SNAPSHOT.99")
+val mcJavaVersion by extra("2.0.0-SNAPSHOT.101")
 val javadocToolsVersion by extra("2.0.0-SNAPSHOT.74")
-val baseVersion by extra("2.0.0-SNAPSHOT.107")
+val baseVersion by extra("2.0.0-SNAPSHOT.108")
 
 /**
  * The version of `spine-time` required during the development pre-2.0.0 release
@@ -37,4 +37,4 @@ val baseVersion by extra("2.0.0-SNAPSHOT.107")
 val timeVersion by extra("2.0.0-SNAPSHOT.96")
 
 /** The version of this library. */
-val versionToPublish by extra("2.0.0-SNAPSHOT.97")
+val versionToPublish by extra("2.0.0-SNAPSHOT.108")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -28,13 +28,5 @@ val mcJavaVersion by extra("2.0.0-SNAPSHOT.101")
 val javadocToolsVersion by extra("2.0.0-SNAPSHOT.74")
 val baseVersion by extra("2.0.0-SNAPSHOT.108")
 
-/**
- * The version of `spine-time` required during the development pre-2.0.0 release
- * in order to address version conflicts in Gradle plugins.
- *
- * `base-types` codebase does not have compile-time dependencies onto `spine-time`.
- */
-val timeVersion by extra("2.0.0-SNAPSHOT.96")
-
 /** The version of this library. */
 val versionToPublish by extra("2.0.0-SNAPSHOT.108")


### PR DESCRIPTION
This PR updates the `mc-java` dependency to the latest available. With it, the generated code now becomes dependent onto the newly released runtime library for generated validation code in Java.

Also, it is no longer required to force `time` version. It is now possible to omit such an operation, since all codegen libraries have no external dependencies.

Additionally, the fresh `config` contents were grabbed, and some warnings in the build log were removed by configuring the appropriate dependencies between Gradle tasks.

This PR depends on https://github.com/SpineEventEngine/mc-java/pull/57.

The library version is set to `2.0.0-SNAPSHOT.108` to match the version of `base`.