### PR TITLE
Remove dependency on `spine-validate`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,19 +61,17 @@ buildscript {
         io.spine.internal.gradle.publish.PublishingRepos.gitHub("mc-java")
     }
 
-    val mcJavaVersion: String by extra
-    val baseVersion: String by extra
+    val spine = io.spine.internal.dependency.Spine(project)
     dependencies {
-        classpath("io.spine.tools:spine-mc-java-plugins:${mcJavaVersion}:all")
+        classpath(spine.mcJavaPlugin)
     }
 
-    val dokka = io.spine.internal.dependency.Dokka
     configurations {
         all {
             resolutionStrategy {
                 force(
-                    "org.jetbrains.dokka:dokka-base:${dokka.version}",
-                    "io.spine:spine-base:$baseVersion",
+                    io.spine.internal.dependency.Dokka.BasePlugin.lib,
+                    spine.base,
                 )
             }
         }
@@ -105,6 +103,8 @@ repositories {
     applyStandard()
 }
 
+val spine = io.spine.internal.dependency.Spine(project)
+
 configurations {
     forceVersions()
     excludeProtobufLite()
@@ -115,7 +115,8 @@ configurations {
             force(
                 "org.jetbrains.dokka:dokka-base:${Dokka.version}",
                 Protobuf.compiler,
-                "io.spine:spine-base:$baseVersion",
+                spine.base,
+                spine.validation.runtime,
             )
         }
     }
@@ -131,11 +132,11 @@ apply<VersionWriter>()
 dependencies {
     errorprone(ErrorProne.core)
 
-    implementation("io.spine:spine-base:$baseVersion")
-    implementation("io.spine:spine-validate:$baseVersion")
+    implementation(spine.base)
+    implementation(spine.validation.runtime)
 
     testImplementation(JUnit.runner)
-    testImplementation("io.spine.tools:spine-testlib:$baseVersion")
+    testImplementation(spine.testlib)
 }
 
 spinePublishing {

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -58,6 +58,11 @@ class Spine(p: ExtensionAware) {
         const val mc = "2.0.0-SNAPSHOT.90"
 
         /**
+         * The version of `mc-java` to use.
+         */
+        const val mcJava = "2.0.0-SNAPSHOT.102"
+
+        /**
          * The version of `base-types` to use.
          * @see [Spine.baseTypes]
          */
@@ -113,6 +118,8 @@ class Spine(p: ExtensionAware) {
 
     val modelCompiler = "$toolsGroup:spine-model-compiler:${p.mcVersion}"
 
+    val mcJavaPlugin = "io.spine.tools:spine-mc-java-plugins:${p.mcJavaVersion}:all"
+
     val validation = Validation(p)
 
     private val ExtensionAware.baseVersion: String
@@ -126,6 +133,9 @@ class Spine(p: ExtensionAware) {
 
     private val ExtensionAware.mcVersion: String
         get() = "mcVersion".asExtra(this, DefaultVersion.mc)
+
+    private val ExtensionAware.mcJavaVersion: String
+        get() = "mcJavaVersion".asExtra(this, DefaultVersion.mcJava)
 
     private val ExtensionAware.toolBaseVersion: String
         get() = "toolBaseVersion".asExtra(this, DefaultVersion.toolBase)
@@ -173,12 +183,9 @@ class Spine(p: ExtensionAware) {
  *         If `null` then rely on the property declaration, even if this would cause an error.
  */
 private fun String.asExtra(p: ExtensionAware, defaultValue: String? = null): String {
-    if (defaultValue != null) {
-        if (p.extra.has(this)) {
-            return p.extra[this] as String
-        }
-        return defaultValue
+    return if (p.extra.has(this) || defaultValue == null) {
+        p.extra[this] as String
+    } else {
+        defaultValue
     }
-    return p.extra[this] as String
 }
-

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/protobuf/ProtoTaskExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/protobuf/ProtoTaskExtensions.kt
@@ -169,7 +169,7 @@ private const val SUPPRESS_DEPRECATION = "@file:Suppress(\"DEPRECATION\")"
  * This file adds [SUPPRESS_DEPRECATION] to the top of a Kotlin file generated
  * by Protobuf compiler.
  */
-private fun suppressDeprecationsInKotlin(generatedDir: String, ssn: String) {
+fun suppressDeprecationsInKotlin(generatedDir: String, ssn: String) {
     val kotlinDir = File("${generatedDir}/${ssn}/kotlin")
 
     kotlinDir.walk().iterator().forEachRemaining {

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base-types:2.0.0-SNAPSHOT.109`
+# Dependencies of `io.spine:spine-base-types:2.0.0-SNAPSHOT.110`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -48,7 +48,7 @@
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.6.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.29.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.32.**No license information found**
 1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.5.
      * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
@@ -269,7 +269,7 @@
 1.  **Group** : io.spine.protodata. **Name** : protodata-fat-cli. **Version** : 0.2.16.**No license information found**
 1.  **Group** : io.spine.protodata. **Name** : protodata-protoc. **Version** : 0.2.16.**No license information found**
 1.  **Group** : io.spine.validation. **Name** : spine-validation-java-extensions. **Version** : 2.0.0-SNAPSHOT.29.**No license information found**
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.29.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.32.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -546,4 +546,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 13 16:45:02 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 13 21:09:29 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base-types</artifactId>
-<version>2.0.0-SNAPSHOT.109</version>
+<version>2.0.0-SNAPSHOT.110</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -30,15 +30,9 @@ all modules and does not describe the project structure per-subproject.
     <scope>compile</scope>
   </dependency>
   <dependency>
-    <groupId>io.spine</groupId>
-    <artifactId>spine-validate</artifactId>
-    <version>2.0.0-SNAPSHOT.113</version>
-    <scope>compile</scope>
-  </dependency>
-  <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-runtime</artifactId>
-    <version>2.0.0-SNAPSHOT.29</version>
+    <version>2.0.0-SNAPSHOT.32</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@ val javadocToolsVersion by extra("2.0.0-SNAPSHOT.74")
 val baseVersion by extra("2.0.0-SNAPSHOT.113")
 
 /** The version of this library. */
-val versionToPublish by extra("2.0.0-SNAPSHOT.109")
+val versionToPublish by extra("2.0.0-SNAPSHOT.110")


### PR DESCRIPTION
This PR replaces the dependency on `spine-validate` to `spine-java-validation-runtime`.