### PR TITLE
Force delayed configurations for publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,8 +108,10 @@ configurations {
             Grpc.forceArtifacts(project, this@all, this@resolutionStrategy)
             Jackson.forceArtifacts(project, this@all, this@resolutionStrategy)
             Jackson.DataType.forceArtifacts(project, this@all, this@resolutionStrategy)
+            Jackson.DataFormat.forceArtifacts(project, this@all, this@resolutionStrategy)
             force(
                 Grpc.bom,
+                Jackson.bom,
                 Base.annotations,
                 Base.lib,
                 Base.environment,

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base-types:2.0.0-SNAPSHOT.221`
+# Dependencies of `io.spine:spine-base-types:2.0.0-SNAPSHOT.222`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1026,6 +1026,6 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 22 18:25:07 WET 2025** using 
+This report was generated on **Mon Dec 22 19:16:57 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base-types</artifactId>
-<version>2.0.0-SNAPSHOT.221</version>
+<version>2.0.0-SNAPSHOT.222</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  *  For dependencies on Spine modules please see [io.spine.dependency.local.Spine].
  */
-val versionToPublish by extra("2.0.0-SNAPSHOT.221")
+val versionToPublish by extra("2.0.0-SNAPSHOT.222")


### PR DESCRIPTION
This PR forces Jackson and other dependencies resolution of which is delayed until Dokka starts working. The absence of forced versions [failed publishing of the documentation for the previous PR](https://github.com/SpineEventEngine/base-types/actions/runs/20440699053/job/58735007541).